### PR TITLE
Add Support to validate commits with .git directory in another location

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ However you can mute it:
 $ validate-commit-msg -s 'unknown(something): wrong'
 ```
 
+
+Validate a commit with .git directory in another location
+
+```bash
+$ validate-commit-msg --mf ../../some/.git/module/COMMIT_EDITMSG 'New: Awesome feature' 
+```
+
+
 ### Within node
 
 ```javascript
@@ -124,6 +132,7 @@ This module, like many others, installs an executable in **./node_modules/.bin**
     -V, --version          output the version number
     -p, --preset <preset>  specify a preset (angular|atom|eslint|ember|jquery|jshint) [angular]
     -s, --silent           mute log messages [false]
+    --mf --msgfile         relative path to COMMIT_EDITMSG file 
 ```
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ validate-commit-msg -s 'unknown(something): wrong'
 Validate a commit with .git directory in another location
 
 ```bash
-$ validate-commit-msg --mf ../../some/.git/module/COMMIT_EDITMSG 'New: Awesome feature' 
+$ validate-commit-msg --mf ../../some/.git/module/COMMIT_EDITMSG
 ```
 
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,29 +20,38 @@ var argv = yargs
     default: false,
     description: 'mute log messages'
   })
+  .option('msgfile', {
+    alias: 'mf',
+    type: 'string',
+    default: false,
+    description: 'path to COMMIT_EDITMSG file'
+  })
   .version()
   .help().argv;
 
 var valid = false;
 
+var workingDirectory =  process.cwd()
 var message = argv._[0];
+var msgfile = argv.mf
 var options = {
   preset: argv.preset
 };
+
 
 if (argv.silent) {
   process.env.SILENT = true;
 }
 
 if (message === undefined) {
-  var gitFolder = path.resolve(process.cwd(), '.git');
+  var gitFolder = path.resolve(workingDirectory, '.git');
 
   if (!gitFolder) {
     throw new Error('No .git folder found');
   }
-
-  var commitMsgFile = path.resolve(gitFolder, 'COMMIT_EDITMSG');
-
+  
+  var commitMsgFile =  msgfile ? path.resolve(workingDirectory , msgfile) : path.resolve(gitFolder, 'COMMIT_EDITMSG');
+  
   valid = validate.validateMessageFromFile(commitMsgFile, options);
 } else {
   if (isFile(message)) {
@@ -56,3 +65,4 @@ if (valid === false) {
   process.exit(1);
 }
 process.exit(0);
+

--- a/bin/index.js
+++ b/bin/index.js
@@ -31,9 +31,9 @@ var argv = yargs
 
 var valid = false;
 
-var workingDirectory =  process.cwd()
+var workspaceRoot =  process.cwd()
 var message = argv._[0];
-var msgfile = argv.mf
+var msgFile = argv.mf
 var options = {
   preset: argv.preset
 };
@@ -44,13 +44,14 @@ if (argv.silent) {
 }
 
 if (message === undefined) {
-  var gitFolder = path.resolve(workingDirectory, '.git');
+
+  var gitFolder = path.resolve(workspaceRoot, '.git');
 
   if (!gitFolder) {
     throw new Error('No .git folder found');
   }
-  
-  var commitMsgFile =  msgfile ? path.resolve(workingDirectory , msgfile) : path.resolve(gitFolder, 'COMMIT_EDITMSG');
+
+  var commitMsgFile =  msgFile ? path.resolve(workspaceRoot , msgFile) : path.resolve(gitFolder, 'COMMIT_EDITMSG');
   
   valid = validate.validateMessageFromFile(commitMsgFile, options);
 } else {

--- a/bin/index.js
+++ b/bin/index.js
@@ -24,7 +24,7 @@ var argv = yargs
     alias: 'mf',
     type: 'string',
     default: false,
-    description: 'path to COMMIT_EDITMSG file'
+    description: 'relative path to COMMIT_EDITMSG file'
   })
   .version()
   .help().argv;
@@ -65,4 +65,3 @@ if (valid === false) {
   process.exit(1);
 }
 process.exit(0);
-

--- a/bin/index.js
+++ b/bin/index.js
@@ -38,7 +38,6 @@ var options = {
   preset: argv.preset
 };
 
-
 if (argv.silent) {
   process.env.SILENT = true;
 }
@@ -52,7 +51,7 @@ if (message === undefined) {
   }
 
   var commitMsgFile =  msgFile ? path.resolve(workspaceRoot , msgFile) : path.resolve(gitFolder, 'COMMIT_EDITMSG');
-  
+    
   valid = validate.validateMessageFromFile(commitMsgFile, options);
 } else {
   if (isFile(message)) {

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -40,4 +40,33 @@ describe('cli', function() {
 
     expect(fn).to.throw(Error);
   });
+
+  it('should not throw an error with a valid commit msm file', function(done) {
+    this.command.push('--mf .git/COMMIT_EDITMSG');
+
+    let command = this.command.join(' ');
+
+    exec(command, function(error) {
+      if (error) {
+        throw error;
+      }
+
+      expect(error).to.be.null;
+
+      done();
+    });
+  });
+
+  it('should throw an error with a invalid commit msm file', function() {
+    this.command.push('--mf .git/WRONG_COMMIT_EDITMSG');
+
+    let command = this.command.join(' ');
+
+    let fn = () => {
+      return execSync(command);
+    };
+
+    expect(fn).to.throw(Error);
+  });
+
 });

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -42,7 +42,7 @@ describe('cli', function() {
   });
 
   it('should not throw an error with a valid commit msm file', function(done) {
-    this.command.push('--mf .git/COMMIT_EDITMSG');
+    this.command.push('--mf ./test/fixtures/angular/valid.txt');
 
     let command = this.command.join(' ');
 
@@ -70,3 +70,4 @@ describe('cli', function() {
   });
 
 });
+


### PR DESCRIPTION
I have added the --msgfile option to specify the path to the  COMMIT_EDITMSG file to validate commits in submodules.

example:

"scripts": {
    "commitmsg": "validate-commit-msg -p eslint --mf ../../.git/modules/api/COMMIT_EDITMSG"
}